### PR TITLE
Switch to stable version of spatie/laravel-package-tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^7.4|^8.0",
         "guzzlehttp/psr7": "^1.8",
         "league/openapi-psr7-validator": "^0.16",
-        "spatie/laravel-package-tools": "dev-master"
+        "spatie/laravel-package-tools": "^1.11"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.18",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "guzzlehttp/psr7": "^1.8",
-        "league/openapi-psr7-validator": "^0.16",
+        "league/openapi-psr7-validator": "^0.17",
         "spatie/laravel-package-tools": "^1.11"
     },
     "require-dev": {


### PR DESCRIPTION
The branch `master` is renamed to `main` and a stable version preferred to avoid breaking changes. 